### PR TITLE
[Fix] Event Integration 테스트 오류 및 Redis 초기화 스크립트 수정

### DIFF
--- a/src/main/java/kr/kro/airbob/domain/event/EventService.java
+++ b/src/main/java/kr/kro/airbob/domain/event/EventService.java
@@ -21,31 +21,37 @@ public class EventService {
 
     private final StringRedisTemplate redisTemplate;
     private final EventRepository eventRepository;
-
-    private final String APPLY_EVENT_SCRIPT = """
+    private static final String APPLY_EVENT_SCRIPT = """
         local memberId = ARGV[1]
         local maxQueueSize = tonumber(ARGV[2])
+        local ttlSeconds = tonumber(ARGV[3])
         
         local zsetKey = KEYS[1]
         local seqKey = KEYS[2]
         
+        -- 현재 큐 크기 조회
+        local currentSize = redis.call('ZCARD', zsetKey)
+        
+        -- 큐가 꽉 찼으면 'full' 반환
+        if currentSize >= maxQueueSize then
+            return "full"
+        end
+        
         -- 순번 증가 (score로 사용)
         local score = redis.call('INCR', seqKey)
         
-        -- 추가
+        -- 중복 멤버가 아니면 추가
         local added = redis.call('ZADD', zsetKey, 'NX', score, memberId)
         if added == 0 then
             return "duplicate"
         end
         
-        -- 순위 확인
-        local rank = redis.call('ZRANK', zsetKey, memberId)
-        if rank >= maxQueueSize then
-            return "full"
-        end
+        -- TTL 설정
+        redis.call('EXPIRE', zsetKey, ttlSeconds)
         
         return "success"
     """;
+
     @Transactional
     @CircuitBreaker(name = "redisEventQueue", fallbackMethod = "fallback")
     public ApplyResult applyToEvent(Long eventId, Long memberId, int maxParticipants) {
@@ -56,21 +62,21 @@ public class EventService {
         String zsetKey = "event:" + eventId + ":zset";
         String seqKey = "event:" + eventId + ":seq";
 
+
         String result = redisTemplate.execute(
                 script,
                 Arrays.asList(zsetKey, seqKey),
                 String.valueOf(memberId),
-                String.valueOf(maxParticipants)
+                String.valueOf(maxParticipants),
+                String.valueOf(300)
         );
-
-
-        long ttlSeconds = 300L;
-        redisTemplate.expire(zsetKey, Duration.ofSeconds(ttlSeconds));
 
         return ApplyResult.valueOf(result.toUpperCase());
     }
 
     private ApplyResult fallback(Throwable t) {
+        log.info(t.getMessage());
+        log.info(String.valueOf(t.getCause()));
         return ApplyResult.ERROR;
     }
     @Cacheable(value = "eventMaxParticipantsCache", key = "'event:' + #eventId + ':maxParticipants'")

--- a/src/main/java/kr/kro/airbob/domain/event/common/ApplyResult.java
+++ b/src/main/java/kr/kro/airbob/domain/event/common/ApplyResult.java
@@ -19,4 +19,15 @@ public enum ApplyResult {
     public ResponseEntity<String> toResponse() {
         return ResponseEntity.status(status).body(message);
     }
+
+    public static ApplyResult from(String raw) {
+        if (raw == null) return ERROR;
+
+        return switch (raw.trim().toLowerCase()) {
+            case "success" -> SUCCESS;
+            case "duplicate" -> DUPLICATE;
+            case "full" -> FULL;
+            default -> ERROR;
+        };
+    }
 }

--- a/src/test/java/kr/kro/airbob/domain/event/EventServiceIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/event/EventServiceIntegrationTest.java
@@ -25,6 +25,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -113,34 +114,31 @@ class EventServiceIntegrationTest {
         assertThat(duplicateCount).isEqualTo(threadCount - 1);
     }
 
-//    @Test
-//    @DisplayName("최대 인원 수를 초과한 요청이 와도 큐에는 최대 인원 수만 저장된다")
-//    void queueShouldNotExceedMaxParticipants() throws InterruptedException {
-//        // given
-//        Long eventId = 1L;
-//        int maxParticipants = 100;
-//        int requestCount = 150;
-//
-//        // when
-//        ExecutorService executor = Executors.newFixedThreadPool(20);
-//        CountDownLatch latch = new CountDownLatch(requestCount);
-//        for (int i = 0; i < requestCount; i++) {
-//            final long memberId = i + 1;
-//            executor.submit(() -> {
-//                eventService.applyToEvent(eventId, memberId, maxParticipants);
-//                latch.countDown();
-//            });
-//        }
-//
-//        latch.await();
-//
-//        // then
-//        List<String> queue = redisTemplate.opsForList().range("event:" + eventId + ":queue", 0, -1);
-//        Set<String> uniqueSet = new HashSet<>(queue); // 중복 제거
-//
-//        assertThat(queue.size()).isEqualTo(maxParticipants);
-//        assertThat(uniqueSet.size()).isEqualTo(maxParticipants); // 중복도 없음을 확인
-//    }
+    @Test
+    @DisplayName("최대 인원 수를 초과한 요청이 와도 zset에는 최대 인원 수만 저장된다")
+    void zsetShouldNotExceedMaxParticipants() throws InterruptedException {
+        // given
+        Long eventId = 1L;
+        int maxParticipants = 100;
+        int requestCount = 150;
+
+        // when
+        ExecutorService executor = Executors.newFixedThreadPool(20);
+        CountDownLatch latch = new CountDownLatch(requestCount);
+        for (int i = 0; i < requestCount; i++) {
+            final long memberId = i + 1;
+            executor.submit(() -> {
+                eventService.applyToEvent(eventId, memberId, maxParticipants);
+                latch.countDown();
+            });
+        }
+
+        latch.await();
+
+        // then
+        Set<String> members = redisTemplate.opsForZSet().range("event:" + eventId + ":zset", 0, -1);
+        assertThat(members.size()).isEqualTo(maxParticipants);
+    }
 
     @Test
     @DisplayName("선착순 인원에 들면 응모가 성공한다.")

--- a/src/test/java/kr/kro/airbob/domain/event/EventServiceIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/event/EventServiceIntegrationTest.java
@@ -80,7 +80,7 @@ class EventServiceIntegrationTest {
 
     @BeforeEach
     void clearRedis() {
-        redisTemplate.delete(Arrays.asList("event:1:set", "event:1:queue"));
+        redisTemplate.delete(Arrays.asList("event:1:set", "event:1:zset"));
     }
 
     @Test

--- a/src/test/java/kr/kro/airbob/domain/reservation/ReservationIntegrationTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/ReservationIntegrationTest.java
@@ -21,6 +21,7 @@ import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;

--- a/src/test/java/kr/kro/airbob/domain/reservation/ReservationServiceTest.java
+++ b/src/test/java/kr/kro/airbob/domain/reservation/ReservationServiceTest.java
@@ -198,7 +198,7 @@ public class ReservationServiceTest {
 
         // when & then
         assertThrows(InvalidReservationDateException.class, () -> {
-            reservationService.createReservation(1L, dto, 1L);
+            reservationService.validReservationDates(dto);
         });
     }
 


### PR DESCRIPTION
✅ 작업 내용 요약
	•	EventService 통합 테스트 중 발생한 오류 수정
	•	Redis 초기화 스크립트 수정 및 개선
	•	동시성 테스트 안정성 향상
	•	Redis Lua 스크립트 및 키 관리 개선

🔍 상세 내용
	•	Redis 테스트 초기화 시 사용 키 queue -> zset 변경
	•	동시성 테스트에서 발생하는 중복 처리 로직 보완
	•	Lua 스크립트 내 큐 크기 체크 로직 및 데이터 관리 수정